### PR TITLE
Resolve symlink when attempting to resolve git-completion

### DIFF
--- a/git-completion.zsh
+++ b/git-completion.zsh
@@ -33,7 +33,7 @@ if [ -z "$script" ]; then
 		bash_completion='/usr/share/bash-completion/completions/'
 
 	locations=(
-		"$(dirname ${funcsourcetrace[1]%:*})"/git-completion.bash
+		"$(dirname $(realpath ${funcsourcetrace[1]%:*}))"/git-completion.bash
 		"$HOME/.local/share/bash-completion/completions/git"
 		'/usr/local/share/bash-completion/completions/git'
 		"$bash_completion/git"


### PR DESCRIPTION
When using zinit via omz gitfast plugin the completion is symlinked
to ~/.zinit/completions. This causes the completion script to not be
able to find the git-completions script which breaks the completion