### PR TITLE
fix: allow plugin to work with zinit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ zshfuncdir := $(sharedir)/zsh
 all:
 
 test:
+	ln -s git-completion.zsh t/zsh/_git
 	$(MAKE) -C t
 
 D = $(DESTDIR)

--- a/t/.gitignore
+++ b/t/.gitignore
@@ -1,3 +1,4 @@
 /test-results/
 /trash directory.*/
 /.prove
+/zsh/_git

--- a/t/zsh/_git
+++ b/t/zsh/_git
@@ -1,1 +1,0 @@
-../../git-completion.zsh


### PR DESCRIPTION
* zinit does not play well with symlinked completions
* zinit will pick up this completion, which ends up breaking the git completion and preventing the git-completion.zsh from being used

Also, unlike the documentation states, I found that a standard plugin load did _not_ work me. I needed:

```
blockf ver"zinit-fixed" as"completion" nocompile mv'git-completion.zsh -> _git' iloveitaly/git-completion
```