### PR TITLE
completion: zsh: update alias config regexp to '^alias\.'

### DIFF
--- a/src/_git
+++ b/src/_git
@@ -173,7 +173,7 @@ __git_zsh_cmd_common ()
 __git_zsh_cmd_alias ()
 {
 	local -a list
-	list=(${${(0)"$(git config -z --get-regexp '^alias\.*')"}#alias.})
+	list=(${${(0)"$(git config -z --get-regexp '^alias\.')"}#alias.})
 	list=(${(f)"$(printf "%s:alias for '%s'\n" ${(f@)list})"})
 	_describe -t alias-commands 'aliases' list && _ret=0
 }

--- a/t/completion-zsh.t
+++ b/t/completion-zsh.t
@@ -996,6 +996,15 @@ test_expect_success 'complete files' '
 	test_completion "git add mom" "momified"
 '
 
+test_expect_success "list aliases" '
+	test_config alias.foo checkout &&
+	test_config alias-foo.bar irrelevant &&
+	test_completion "git foo" <<-\EOF
+	foo
+	EOF
+	test_completion "git alias-foo" ""
+'
+
 test_expect_success "simple alias" '
 	test_config alias.co checkout &&
 	test_completion "git co m" <<-\EOF


### PR DESCRIPTION
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
I have a custom alias-helper.* section [1] in my Git config, and the old
regexp captured them too.

[1] https://git.tsundere.moe/Frederick888/frederick-settings/-/blob/7061da1a9f033bafc99ea82243822bc02417e2c1/.gitconfig#L9-37
<!-- === GH HISTORY FENCE === -->
